### PR TITLE
Backward physical-memory assignment emulation and a bug-fix in INT 21H AX=250AH

### DIFF
--- a/src/f386data.asm
+++ b/src/f386data.asm
@@ -60,7 +60,7 @@ PM_stack_adr	dd	0		;プロテクトモード時のスタック
 V86_cs		dw	0,0		;V86モード時 cs
 V86_sp		dw	0,0		;V86モード時 sp
 
-emulate_backward	db	0	; If non-zero, emulate backward physical-memory assignment.
+emulate_backward	dd	0FFFFFFFFh	; Emulate backward physical-memory assignment above this page.
 
 		align	4
 GDT_adr		dd	0

--- a/src/f386data.asm
+++ b/src/f386data.asm
@@ -60,6 +60,8 @@ PM_stack_adr	dd	0		;プロテクトモード時のスタック
 V86_cs		dw	0,0		;V86モード時 cs
 V86_sp		dw	0,0		;V86モード時 sp
 
+emulate_backward	db	0	; If non-zero, emulate backward physical-memory assignment.
+
 		align	4
 GDT_adr		dd	0
 LDT_adr		dd	0
@@ -187,6 +189,7 @@ msg_10	db	13,10,'Usage: free386 <target.exp>',13,10
 %if TOWNS
 	db	'  -n		Do not load NSD driver',13,10
 %endif
+	db	'  -b		Emulate backward physical memory assignment.',13,10
 	db	'  -maxreal nn	Set minimum dos free memory [byte]' ,13,10
 	db	'  -minreal nn	Set maximum dos free memory [byte]' ,13,10
 	db	'  -callbuf nn	Set user call buffer size [KB]',13,10

--- a/src/free386.asm
+++ b/src/free386.asm
@@ -221,7 +221,7 @@ proc2 parameter_check
 	; -b for backward physical-memory assignment
 	;///////////////////////////////
 .para_b:
-	mov	b [emulate_backward],1
+	mov	d [emulate_backward],0C0h
 	jmp	.loop
 
 	;///////////////////////////////

--- a/src/free386.asm
+++ b/src/free386.asm
@@ -221,7 +221,6 @@ proc2 parameter_check
 	; -b for backward physical-memory assignment
 	;///////////////////////////////
 .para_b:
-	out 0xEA,AL
 	mov	b [emulate_backward],1
 	jmp	.loop
 

--- a/src/free386.asm
+++ b/src/free386.asm
@@ -155,6 +155,8 @@ proc2 parameter_check
 	cmp	al,'n'
 	je	.para_n
 %endif
+	cmp	al,'b'
+	je	.para_b
 	cmp	al,'i'
 	je	.para_i
 	jmp	.loop
@@ -214,6 +216,14 @@ proc2 parameter_check
 	mov	b [load_nsdd],ah
 	jmp	.loop
 %endif
+
+	;///////////////////////////////
+	; -b for backward physical-memory assignment
+	;///////////////////////////////
+.para_b:
+	out 0xEA,AL
+	mov	b [emulate_backward],1
+	jmp	.loop
 
 	;///////////////////////////////
 	; set PharLap version to 2.2 (compatible EXE386)

--- a/src/int_dosx.asm
+++ b/src/int_dosx.asm
@@ -344,7 +344,7 @@ proc4 DOSX_fn_250ah
 
 	mov	eax, ebp	;eax = old size
 	shr	eax, 12
-	mov	eax, ecx	;eax = new size/4K
+	add	eax, ecx	;eax = new size/4K
 	dec	eax		;eax = limit
 
 	;-------------------------------------------------------------

--- a/src/int_dosx.asm
+++ b/src/int_dosx.asm
@@ -333,7 +333,7 @@ proc4 DOSX_fn_250ah
 	test	edi, 0fffh	;UNIT is 4K?
 	jnz	.fail0
 
-	mov	esi, ecx	;esi = map linear address
+	mov	esi, edi	;esi = map linear address
 	mov	edx, [esp]	;edx = map phisical address
 	mov	ecx, [esp+4]	;ecx = map pages
 	test	ecx, ecx

--- a/src/memory.inc
+++ b/src/memory.inc
@@ -38,3 +38,4 @@ extern	gp_buffer_table
 extern	sw_stack_bottom
 extern	sw_stack_bottom_orig
 
+extern	emulate_backward

--- a/src/selector.asm
+++ b/src/selector.asm
@@ -387,7 +387,6 @@ proc4 allocate_RAM
 	mov	edi, [freeRAM_bm_ladr]	;edi - free RAM bitmap
 	xor	ebp, ebp
 
-	out 0xEA,AL
 .loop:
 	cmp	b [emulate_backward],0
 	je	.simple_increment

--- a/src/selector.asm
+++ b/src/selector.asm
@@ -387,7 +387,7 @@ proc4 allocate_RAM
 	mov	edi, [freeRAM_bm_ladr]	;edi - free RAM bitmap
 	xor	ebp, ebp
 
-; while(page[ebp] is not available && all pages assigned)
+; while(until all pages assigned)
 ; {
 ; 	if(border<=ebp)
 ; 	{
@@ -401,8 +401,12 @@ proc4 allocate_RAM
 ; 			ebp=all_mem_pages-1;
 ; 		}
 ; 	}
-; 	Use page[ebp]
+; 	if(page[ebp] is available)
+; 	{
+; 		Use page[ebp]
+; 	}
 ; }
+
 .loop:
 	cmp	ebp,[emulate_backward]
 	jae	.reverse_assignment

--- a/src/selector.asm
+++ b/src/selector.asm
@@ -386,11 +386,40 @@ proc4 allocate_RAM
 	;---------------------------------------------------
 	mov	edi, [freeRAM_bm_ladr]	;edi - free RAM bitmap
 	xor	ebp, ebp
+
+	out 0xEA,AL
 .loop:
+	cmp	b [emulate_backward],0
+	je	.simple_increment
+
+	cmp	ebp,0C0h
+	jae	.reverse_assignment
+
+	inc	ebp
+	cmp	ebp,0C0h
+	jae	.crossed_border
+
+	btr	es:[edi], ebp
+	jnc	.loop
+	jmp	.found_free_memory
+
+.crossed_border:
+	mov	ebp,[all_mem_pages]
+
+.reverse_assignment:
+	dec	ebp
+	btr	es:[edi], ebp
+	jnc	.loop
+	jmp	.found_free_memory
+
+.simple_increment:
+
+
 	inc	ebp
 	btr	es:[edi], ebp
 	jnc	.loop
 
+.found_free_memory:
 	; found free memory
 	mov	eax, ebp
 	shl	eax, 12			;eax = free RAM address

--- a/src/selector.asm
+++ b/src/selector.asm
@@ -394,16 +394,12 @@ proc4 allocate_RAM
 	cmp	ebp,0C0h
 	jae	.reverse_assignment
 
-	inc	ebp
-	cmp	ebp,0C0h
-	jae	.crossed_border
+	cmp	ebp,0BFh
+	jne	.simple_increment
 
-	btr	es:[edi], ebp
-	jnc	.loop
-	jmp	.found_free_memory
+	; Comes here only if incoming ebp is 0BFh.  i.e., Incrementing EBP will cross the border.
 
-.crossed_border:
-	mov	ebp,[all_mem_pages]
+	mov	ebp,[all_mem_pages]	; Crossed border.
 
 .reverse_assignment:
 	dec	ebp


### PR DESCRIPTION
TOWNSのDOS-Extenderの挙動なのですが、INT 21H AH=48Hでmallocしたとき、0C0000h以上の物理メモリを、線形アドレスに対して後ろから割り当てて行くようです。Galaxy Force 2がその挙動を前提に書いてあるため、これをエミュレートしないとGalaxy Force 2を互換TOWNS OSから起動できませんでした。

そこで、コマンドオプション -b を指定すると逆向きの物理メモリ割り当てを再現するようにしてみました。この修正で、Galaxy Force 2が起動してプレイ可能なことを確認しました。まだ互換TBIOS (津軽BIOS) が不完全なため音声が鳴りっぱなしになったりするという問題はありますが、これは間もなく修正できると思います。他にも既に使用可能になっていたプログラム数本試して問題なく動作したので、オプションをつけなければ従来使えていたものはそのまま使えると思います。

それから、INT 21H AX=250AHで、多分 mov esi,edi とするべきところが、 mov esi,ecx となっていたのと、add eax,ecx とするべきところが mov eax,ecx となっていたので修正しました。

Pull Requestにしましたので、ご検討ください。

おかげ様で、互換TOWNS OSプロジェクトはかなり進んでます。既にフリーソフト、Panic Ball 2, VSGP, Sky Duel, Alltynexに加えて、Afterburner 2までもが本家TOWNS OSのファイルを一切使わずプレイ可能になりました。free386の完成度の高さはすごいですね!